### PR TITLE
fix: Add prepend: true to Emotion cache, so TailwindCSS can override …

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,6 +14,7 @@ export const metadata: Metadata = {
 
 const CACHE_PROVIDER_OPTIONS = {
   key: "css",
+  prepend: true,
 };
 
 export default function RootLayout({


### PR DESCRIPTION
…style easily

Context: [Slack](https://czi-sci.slack.com/archives/C024AUM646Q/p1724194864173409)

We had issue overriding SDS Button with `text-trasnform: lowercase` via Tailwind CSS `lowercase` class

Turned out that according to the docs below, we just need to add `prepend: true` to the cache. So setting this up by default in the template!

https://mui.com/material-ui/integrations/interoperability/#tailwind-css

<img width="921" alt="Screenshot 2024-08-21 at 8 38 43 AM" src="https://github.com/user-attachments/assets/b55c0b1d-ae9d-4a29-a36a-fb499741ba77">
